### PR TITLE
Add GetQualifyingStripes to IndexStructure.

### DIFF
--- a/common/bitmap.h
+++ b/common/bitmap.h
@@ -78,6 +78,9 @@ class Bitmap64 {
     for (size_t i = 0; i < bits(); ++i) bitset_[i] = fill_value;
   }
 
+  // Calls copy constructor of underlying boost dynamic bitset.
+  Bitmap64(const Bitmap64& other) : bitset_(other.bitset_) {}
+
   size_t bits() const { return bitset_.size(); }
 
   bool Get(size_t pos) const { return bitset_[pos]; }

--- a/cuckoo_index.cc
+++ b/cuckoo_index.cc
@@ -244,7 +244,8 @@ bool CuckooIndex::StripeContains(size_t stripe_id, int value) const {
   return slot_bitmaps_[slot]->Get(stripe_id);
 }
 
-Bitmap64 CuckooIndex::GetQualifyingStripes(int value, int num_stripes) const {
+Bitmap64 CuckooIndex::GetQualifyingStripes(int value,
+                                           size_t num_stripes) const {
   const CuckooValue val(value, num_buckets_);
   size_t slot;
   if (!BucketContains(val.primary_bucket, val.fingerprint, &slot)) {

--- a/cuckoo_index.cc
+++ b/cuckoo_index.cc
@@ -255,10 +255,7 @@ Bitmap64 CuckooIndex::GetQualifyingStripes(int value, int num_stripes) const {
   }
   assert(slot_bitmaps_[slot] != nullptr);
   const Bitmap64& bitmap = *slot_bitmaps_[slot];
-  Bitmap64 result(bitmap.bits());
-  for (const size_t index : bitmap.TrueBitIndices())
-    result.Set(index, true);
-  return result;
+  return Bitmap64(bitmap);
 }
 
 bool CuckooIndex::BucketContains(size_t bucket, uint64_t fingerprint,

--- a/cuckoo_index.cc
+++ b/cuckoo_index.cc
@@ -249,8 +249,8 @@ Bitmap64 CuckooIndex::GetQualifyingStripes(int value, int num_stripes) const {
   size_t slot;
   if (!BucketContains(val.primary_bucket, val.fingerprint, &slot)) {
     if (!BucketContains(val.secondary_bucket, val.fingerprint, &slot)) {
-      // Not found. Return empty bitmap.
-      return Bitmap64(/*size=*/0);
+      // Not found. Return an empty bitmap.
+      return Bitmap64(/*size=*/num_stripes);
     }
   }
   assert(slot_bitmaps_[slot] != nullptr);

--- a/cuckoo_index.h
+++ b/cuckoo_index.h
@@ -30,7 +30,7 @@ class CuckooIndex : public IndexStructure {
  public:
   bool StripeContains(size_t stripe_id, int value) const override;
 
-  Bitmap64 GetQualifyingStripes(int value, int num_stripes) const override;
+  Bitmap64 GetQualifyingStripes(int value, size_t num_stripes) const override;
 
   std::string name() const override { return name_; }
 

--- a/cuckoo_index.h
+++ b/cuckoo_index.h
@@ -30,6 +30,8 @@ class CuckooIndex : public IndexStructure {
  public:
   bool StripeContains(size_t stripe_id, int value) const override;
 
+  Bitmap64 GetQualifyingStripes(int value, int num_stripes) const override;
+
   std::string name() const override { return name_; }
 
   // Returns the in-memory size of the index structure.

--- a/index_structure.h
+++ b/index_structure.h
@@ -37,6 +37,19 @@ class IndexStructure {
   // Returns true iff the stripe with `stripe_id` contains the given `value`.
   virtual bool StripeContains(size_t stripe_id, int value) const = 0;
 
+  // Returns a bitmap indicating possibly qualifying stripes for the given
+  // `value`. Probes up to `num_stripes` stripes.
+  virtual Bitmap64 GetQualifyingStripes(int value, int num_stripes) const {
+    // Default implementation for per-stripe index structures.
+    Bitmap64 result(/*size=*/num_stripes);
+    for (size_t stripe_id = 0; stripe_id < static_cast<size_t>(num_stripes);
+         ++stripe_id) {
+      if (StripeContains(stripe_id, value))
+        result.Set(stripe_id, true);
+    }
+    return result;
+  }
+
   // Returns the name of the index structure.
   virtual std::string name() const = 0;
 

--- a/index_structure.h
+++ b/index_structure.h
@@ -39,7 +39,9 @@ class IndexStructure {
 
   // Returns a bitmap indicating possibly qualifying stripes for the given
   // `value`. Probes up to `num_stripes` stripes.
-  virtual Bitmap64 GetQualifyingStripes(int value, int num_stripes) const {
+  // Note: classes extending IndexStructure can override this method when they
+  // can provide an optimized approach here (see CuckooIndex for an example).
+  virtual Bitmap64 GetQualifyingStripes(int value, size_t num_stripes) const {
     // Default implementation for per-stripe index structures.
     Bitmap64 result(/*size=*/num_stripes);
     for (size_t stripe_id = 0; stripe_id < static_cast<size_t>(num_stripes);

--- a/lookup_benchmark.cc
+++ b/lookup_benchmark.cc
@@ -24,43 +24,40 @@
 // -- --input_file_path='...' --columns_to_test='A,B,C'
 //
 // Example run:
-// Run on (12 X 4500 MHz CPU s)
+// Run on (80 X 3900 MHz CPU s)
 // CPU Caches:
-//   L1 Data 32 KiB (x6)
-//   L1 Instruction 32 KiB (x6)
-//   L2 Unified 1024 KiB (x6)
-//   L3 Unified 8448 KiB (x1)
-// Load Average: 0.70, 0.29, 0.22
-// Benchmark                                                           Time(ns)
+//  L1 Data 32 KiB (x40)
+//  L1 Instruction 32 KiB (x40)
+//  L2 Unified 1024 KiB (x40)
+//  L3 Unified 28160 KiB (x2)
+// Load Average: 0.88, 0.68, 0.71
 // -----------------------------------------------------------------------------
-// PositiveDistinctLookup/country_code/16384/PerStripeBloom/10            14911
-// NegativeLookup/country_code/16384/PerStripeBloom/10                    15312
-// PositiveDistinctLookup/country_code/16384/CLTSecondary/10               5752
-// NegativeLookup/country_code/16384/CLTSecondary/10                       6007
-// PositiveDistinctLookup/country_code/16384/CuckooIndex:1:0.49:0.02      25492
-// NegativeLookup/country_code/16384/CuckooIndex:1:0.49:0.02              22125
-// PositiveDistinctLookup/country_code/16384/CuckooIndex:1:0.84:0.02     483760
-// NegativeLookup/country_code/16384/CuckooIndex:1:0.84:0.02             771757
-// PositiveDistinctLookup/country_code/16384/CuckooIndex:1:0.95:0.02     296864
-// NegativeLookup/country_code/16384/CuckooIndex:1:0.95:0.02             674640
-// PositiveDistinctLookup/country_code/16384/CuckooIndex:1:0.98:0.02     280902
-// NegativeLookup/country_code/16384/CuckooIndex:1:0.98:0.02             766191
-// PositiveDistinctLookup/country_code/16384/PerStripeXor                  1830
-// NegativeLookup/country_code/16384/PerStripeXor                          1833
-// PositiveDistinctLookup/country_code/65536/PerStripeBloom/10             3820
-// NegativeLookup/country_code/65536/PerStripeBloom/10                     3804
-// PositiveDistinctLookup/country_code/65536/CLTSecondary/10               1444
-// NegativeLookup/country_code/65536/CLTSecondary/10                       1453
-// PositiveDistinctLookup/country_code/65536/CuckooIndex:1:0.49:0.02       6010
-// NegativeLookup/country_code/65536/CuckooIndex:1:0.49:0.02               5458
-// PositiveDistinctLookup/country_code/65536/CuckooIndex:1:0.84:0.02     143072
-// NegativeLookup/country_code/65536/CuckooIndex:1:0.84:0.02             240090
-// PositiveDistinctLookup/country_code/65536/CuckooIndex:1:0.95:0.02      79689
-// NegativeLookup/country_code/65536/CuckooIndex:1:0.95:0.02             183355
-// PositiveDistinctLookup/country_code/65536/CuckooIndex:1:0.98:0.02      72320
-// NegativeLookup/country_code/65536/CuckooIndex:1:0.98:0.02             211880
-// PositiveDistinctLookup/country_code/65536/PerStripeXor                   433
-// NegativeLookup/country_code/65536/PerStripeXor                           433
+// Benchmark                                                           Time
+// -----------------------------------------------------------------------------
+// PositiveDistinctLookup/Color/16384/PerStripeBloom/10            28543 ns
+// NegativeLookup/Color/16384/PerStripeBloom/10                    34615 ns
+// PositiveDistinctLookup/Color/16384/CuckooIndex:1:0.49:0.02       2562 ns
+// NegativeLookup/Color/16384/CuckooIndex:1:0.49:0.02                891 ns
+// PositiveDistinctLookup/Color/16384/CuckooIndex:1:0.84:0.02       5240 ns
+// NegativeLookup/Color/16384/CuckooIndex:1:0.84:0.02               5113 ns
+// PositiveDistinctLookup/Color/16384/CuckooIndex:1:0.95:0.02       3845 ns
+// NegativeLookup/Color/16384/CuckooIndex:1:0.95:0.02               4157 ns
+// PositiveDistinctLookup/Color/16384/CuckooIndex:1:0.98:0.02       3396 ns
+// NegativeLookup/Color/16384/CuckooIndex:1:0.98:0.02               3992 ns
+// PositiveDistinctLookup/Color/16384/PerStripeXor                  4768 ns
+// NegativeLookup/Color/16384/PerStripeXor                          3664 ns
+// PositiveDistinctLookup/Color/65536/PerStripeBloom/10             7745 ns
+// NegativeLookup/Color/65536/PerStripeBloom/10                     8782 ns
+// PositiveDistinctLookup/Color/65536/CuckooIndex:1:0.49:0.02       1396 ns
+// NegativeLookup/Color/65536/CuckooIndex:1:0.49:0.02                581 ns
+// PositiveDistinctLookup/Color/65536/CuckooIndex:1:0.84:0.02       4111 ns
+// NegativeLookup/Color/65536/CuckooIndex:1:0.84:0.02               5056 ns
+// PositiveDistinctLookup/Color/65536/CuckooIndex:1:0.95:0.02       2821 ns
+// NegativeLookup/Color/65536/CuckooIndex:1:0.95:0.02               4281 ns
+// PositiveDistinctLookup/Color/65536/CuckooIndex:1:0.98:0.02       2486 ns
+// NegativeLookup/Color/65536/CuckooIndex:1:0.98:0.02               4377 ns
+// PositiveDistinctLookup/Color/65536/PerStripeXor                  1383 ns
+// NegativeLookup/Color/65536/PerStripeXor                           895 ns
 
 #include <cstdlib>
 #include <random>
@@ -100,15 +97,6 @@ bool IsValidSorting(absl::string_view sorting) {
   return values->contains(sorting);
 }
 
-// Probes the first `num_stripes` in the given `index` for the `value`.
-void ProbeAllStripes(const ci::IndexStructure& index, int value,
-                     int num_stripes) {
-  for (size_t stripe_id = 0; stripe_id < static_cast<size_t>(num_stripes);
-       ++stripe_id) {
-    ::benchmark::DoNotOptimize(index.StripeContains(stripe_id, value));
-  }
-}
-
 void BM_PositiveDistinctLookup(const ci::Column& column,
                                std::shared_ptr<ci::IndexStructure> index,
                                const int num_stripes, benchmark::State& state) {
@@ -130,7 +118,8 @@ void BM_PositiveDistinctLookup(const ci::Column& column,
 
   while (state.KeepRunningBatch(values.size())) {
     for (size_t i = 0; i < values.size(); ++i) {
-      ProbeAllStripes(*index, values[i], num_stripes);
+      ::benchmark::DoNotOptimize(index->GetQualifyingStripes(values[i],
+                                                             num_stripes));
     }
   }
 }
@@ -154,7 +143,8 @@ void BM_NegativeLookup(const ci::Column& column,
 
   while (state.KeepRunningBatch(values.size())) {
     for (size_t i = 0; i < values.size(); ++i) {
-      ProbeAllStripes(*index, values[i], num_stripes);
+      ::benchmark::DoNotOptimize(index->GetQualifyingStripes(values[i],
+                                                             num_stripes));
     }
   }
 }


### PR DESCRIPTION
Avoids redundant calls to StripeContains for CuckooIndex.