### PR TITLE
Fix build and improve README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bazel-*
+Vehicle__Snowmobile__and_Boat_Registrations.csv
+.idea/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,10 @@ cc_library(
     hdrs = [
         "data.h",
     ],
+    data = [
+        # Put your csv files here, e.g.
+        # "Vehicle__Snowmobile__and_Boat_Registrations.csv"
+    ],
     deps = [
         ":evaluation_utils",
         "//common:byte_coding",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Cuckoo Index addresses both of these drawbacks of per-partition filters.
 
 Prepare a dataset in a CSV format that you are going to use. One of the datasets we used was DMV [Vehicle, Snowmobile, and Boat Registrations](https://catalog.data.gov/dataset/vehicle-snowmobile-and-boat-registrations).
 
+```
+wget -c https://data.ny.gov/api/views/w4pv-hbkt/rows.csv -O Vehicle__Snowmobile__and_Boat_Registrations.csv
+```
+
+Add the file to the `data` dependencies in the `BUILD.bazel` file.
+
+```
+data = [
+    # Put your csv files here
+    "Vehicle__Snowmobile__and_Boat_Registrations.csv"
+],
+```
+
 For footprint experiments, run the following command, specifying the path to the data file, columns to test, and the tests to run.
 
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,9 +66,9 @@ boost_deps()
 # Protocol buffers.
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "c5fd8f99f0d30c6f9f050bf008e021ccc70d7645ac1f64679c6038e07583b2f3",
-    strip_prefix = "protobuf-d0bfd5221182da1a7cc280f3337b5e41a89539cf",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/d0bfd5221182da1a7cc280f3337b5e41a89539cf.zip"],
+    sha256 = "65e020a42bdab44a66664d34421995829e9e79c60e5adaa08282fd14ca552f57",
+    strip_prefix = "protobuf-3.15.6",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.15.6.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
With bazel 4.0.0 and above, it did not build [1]. Also did some slight improvements to the README and BUILD files to make it easier to run the evaluation.


[1] [https://github.com/bazelbuild/bazel/issues/12887](https://github.com/bazelbuild/bazel/issues/12887)