### PR TITLE
CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+# Bazel build output
 bazel-*
-Vehicle__Snowmobile__and_Boat_Registrations.csv
+
+# CMake build output
+build/
+
+# IDE files
 .idea/
+.vscode/
+
+# Generated protocol buffer sources
+*.pb.cc
+*.pb.h
+
+# Data
+Vehicle__Snowmobile__and_Boat_Registrations.csv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Note: CMake support is community-based. The maintainers do not use CMake internally.
+
+cmake_minimum_required(VERSION 3.18) # For SOURCE_SUBDIR in FetchContent_Declare 
+
+project(cuckooindex CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_compile_options(-Wall -Wextra)
+
+enable_testing()
+
+option(CUCKOOINDEX_BUILD_TESTS "Builds the cuckoo index tests." ON)
+option(CUCKOOINDEX_BUILD_BENCHMARKS "Builds the cuckoo index benchmarks if the tests are built as well." ON)
+
+if(CUCKOOINDEX_BUILD_TESTS)
+  include(tests)
+
+  if(CUCKOOINDEX_BUILD_BENCHMARKS)
+    include(benchmarks)
+  endif()
+endif()
+
+include(cuckooindex)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ bazel run -c opt --cxxopt='-std=c++17' --dynamic_mode=off :lookup_benchmark -- \
   --columns_to_test="City,Zip,Color"
 ```
 
+## CMake support
+
+**NOTE** CMake support is community-based. The maintainers do not use CMake internally.
+
+For further information have a look at the [cmake README](cmake/README.md).
+
 ## Code Organization
 
 #### Evaluation Framework

--- a/bitmap_benchmark_test.cc
+++ b/bitmap_benchmark_test.cc
@@ -50,7 +50,6 @@
 #include "absl/flags/flag.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
-#include "external/com_google_benchmark/_virtual_includes/benchmark/benchmark/benchmark.h"
 
 ABSL_FLAG(std::string, path, "", "Path to bitmap file.");
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,21 @@
+# CMake support
+
+**NOTE** CMake support is community-based. The maintainers do not use CMake internally.
+
+## Including Cuckoo Index in your CMake based project
+
+You can include Cuckoo Index in your own CMake based project like this:
+``` cmake
+include(FetchContent)
+set(CUCKOOINDEX_BUILD_TESTS OFF)
+set(CUCKOOINDEX_BUILD_BENCHMARKS OFF)
+FetchContent_Declare(
+    cuckooindex
+    GIT_REPOSITORY "https://github.com/google/cuckoo-index.git"
+)
+FetchContent_MakeAvailable(cuckooindex)
+FetchContent_GetProperties(cuckooindex SOURCE_DIR CUCKOOINDEX_INCLUDE_DIR)
+include_directories(${CUCKOOINDEX_INCLUDE_DIR})
+
+target_link_libraries(your_target cuckoo_index)
+```

--- a/cmake/absl.cmake
+++ b/cmake/absl.cmake
@@ -1,0 +1,19 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+set(BUILD_TESTING OFF)
+set(ABSL_ENABLE_INSTALL ON)
+set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
+FetchContent_Declare(
+        absl
+        GIT_REPOSITORY "https://github.com/abseil/abseil-cpp.git"
+        GIT_TAG df3ea785d8c30a9503321a3d35ee7d35808f190d
+        PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(absl)
+FetchContent_GetProperties(absl SOURCE_DIR ABSL_INCLUDE_DIR)
+include_directories(${ABSL_INCLUDE_DIR})

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+set(BENCHMARK_ENABLE_TESTING OFF)
+FetchContent_Declare(
+        benchmark
+        GIT_REPOSITORY "https://github.com/google/benchmark.git"
+        GIT_TAG 090faecb454fbd6e6e17a75ef8146acb037118d4
+        PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(benchmark)
+FetchContent_GetProperties(benchmark SOURCE_DIR BENCHMARK_INCLUDE_DIR)
+include_directories(${BENCHMARK_INCLUDE_DIR})

--- a/cmake/benchmarks.cmake
+++ b/cmake/benchmarks.cmake
@@ -1,0 +1,28 @@
+include(benchmark)
+
+add_executable(build_benchmark "${PROJECT_SOURCE_DIR}/build_benchmark.cc")
+target_link_libraries(build_benchmark 
+  cuckoo_index
+  cuckoo_utils
+  index_structure
+  per_stripe_bloom
+  per_stripe_xor
+  common_profiling
+  absl::flags
+  absl::flags_parse
+  benchmark
+  gtest
+)
+
+add_executable(lookup_benchmark "${PROJECT_SOURCE_DIR}/lookup_benchmark.cc")
+target_link_libraries(lookup_benchmark 
+  cuckoo_index
+  cuckoo_utils
+  index_structure
+  per_stripe_bloom
+  per_stripe_xor
+  absl::flags
+  absl::flags_parse
+  benchmark
+  gtest
+)

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,0 +1,18 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+# This is a different version than the one used in the bazel BUILD as it is the first one to support FetchContent_Declare
+# The version in the bazel BUILD can't be updated to this version, though, as boost math is currently in a broken state there
+FetchContent_Declare(
+        boost
+        GIT_REPOSITORY "https://github.com/boostorg/boost.git"
+        GIT_TAG boost-1.77.0
+        PATCH_COMMAND cd <SOURCE_DIR>/libs/math && git checkout v1.77-standalone # Boost math is broken in 1.77.0, apply fixed patch
+)
+FetchContent_MakeAvailable(boost)
+FetchContent_GetProperties(boost SOURCE_DIR BOOST_INCLUDE_DIR)
+include_directories(${BOOST_INCLUDE_DIR})

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,0 +1,33 @@
+add_library(common_byte_coding "${PROJECT_SOURCE_DIR}/common/byte_coding.h")
+target_link_libraries(common_byte_coding
+  absl::strings
+  absl::span
+  libprotobuf-lite
+)
+
+add_library(common_bit_packing "${PROJECT_SOURCE_DIR}/common/bit_packing.h")
+target_link_libraries(common_bit_packing
+  common_byte_coding
+  absl::core_headers
+  absl::endian
+  absl::span
+)
+
+add_library(common_bitmap "${PROJECT_SOURCE_DIR}/common/bitmap.h")
+target_link_libraries(common_bitmap
+  absl::strings
+  Boost::dynamic_bitset
+)
+
+add_library(common_profiling "${PROJECT_SOURCE_DIR}/common/profiling.cc" "${PROJECT_SOURCE_DIR}/common/profiling.h")
+target_link_libraries(common_profiling
+  absl::flat_hash_map
+  absl::time
+)
+
+add_library(common_rle_bitmap "${PROJECT_SOURCE_DIR}/common/rle_bitmap.cc" "${PROJECT_SOURCE_DIR}/common/rle_bitmap.h")
+target_link_libraries(common_rle_bitmap
+  common_bit_packing
+  common_bitmap
+  absl::strings
+)

--- a/cmake/croaring.cmake
+++ b/cmake/croaring.cmake
@@ -1,0 +1,27 @@
+include(ExternalProject)
+find_package(Git REQUIRED)
+
+# Need to use ExternalProject_Add to use custom BUILD_COMMAND
+ExternalProject_Add(
+        croaring_src
+        PREFIX "_deps/croaring"
+        GIT_REPOSITORY "https://github.com/lemire/CroaringUnityBuild.git"
+        GIT_TAG  c1d1a754faa6451436efaffa3fe449edc7710b65
+        TIMEOUT 10
+        CONFIGURE_COMMAND ""
+        UPDATE_COMMAND    ""
+        INSTALL_COMMAND   ""
+        BUILD_ALWAYS      OFF
+        BUILD_COMMAND     ${CMAKE_CXX_COMPILER} -c <SOURCE_DIR>/roaring.c -o libcroaring.o
+        COMMAND           ${CMAKE_COMMAND} -E copy <BINARY_DIR>/libcroaring.o <INSTALL_DIR>/lib/libcroaring.o
+)
+
+ExternalProject_Get_Property(croaring_src install_dir)
+set(CROARING_INCLUDE_DIR ${install_dir}/src/croaring_src)
+set(CROARING_LIBRARY_PATH ${install_dir}/lib/libcroaring.o)
+file(MAKE_DIRECTORY ${CROARING_INCLUDE_DIR})
+add_library(croaring STATIC IMPORTED)
+set_property(TARGET croaring PROPERTY IMPORTED_LOCATION ${CROARING_LIBRARY_PATH})
+set_property(TARGET croaring APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CROARING_INCLUDE_DIR})
+
+add_dependencies(croaring croaring_src)

--- a/cmake/csvparser.cmake
+++ b/cmake/csvparser.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+FetchContent_Declare(
+    csv-parser
+    GIT_REPOSITORY "https://github.com/vincentlaucsb/csv-parser.git"
+    GIT_TAG 6fb1f43ad43fc7962baa3b0fe524b282a56ae4b0
+    PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(csv-parser)
+FetchContent_GetProperties(csv-parser SOURCE_DIR CSV_PARSER_INCLUDE_DIR)
+add_library(csv-parser INTERFACE)
+target_include_directories(csv-parser INTERFACE ${CSV_PARSER_INCLUDE_DIR})

--- a/cmake/cuckooindex.cmake
+++ b/cmake/cuckooindex.cmake
@@ -1,0 +1,182 @@
+# Dependencies
+include(absl)
+include(boost)
+include(croaring)
+include(csvparser)
+include(leveldb)
+include(protobuf)
+include(xor_singleheader)
+
+include_directories(${PROJECT_SOURCE_DIR})
+include(common)
+
+# Get Protobuf include dirs
+get_target_property(protobuf_dirs libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+foreach(dir IN LISTS protobuf_dirs)
+  if ("${dir}" MATCHES "BUILD_INTERFACE")
+    list(APPEND PROTO_DIRS "--proto_path=${dir}")
+  endif()
+endforeach()
+
+# Generate Protobuf cpp sources
+set(PROTO_HDRS)
+set(PROTO_SRCS)
+file(GLOB PROTO_FILES "${PROJECT_SOURCE_DIR}/*.proto")
+
+foreach(PROTO_FILE IN LISTS PROTO_FILES)
+  get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+  set(PROTO_HDR ${PROJECT_SOURCE_DIR}/${PROTO_NAME}.pb.h)
+  set(PROTO_SRC ${PROJECT_SOURCE_DIR}/${PROTO_NAME}.pb.cc)
+
+  add_custom_command(
+    OUTPUT ${PROTO_SRC} ${PROTO_HDR}
+    COMMAND protoc
+    "--proto_path=${PROJECT_SOURCE_DIR}"
+    ${PROTO_DIRS}
+    "--cpp_out=${PROJECT_SOURCE_DIR}"
+    ${PROTO_FILE}
+    DEPENDS ${PROTO_FILE} protoc
+    COMMENT "Generate C++ protocol buffer for ${PROTO_FILE}"
+    VERBATIM)
+  list(APPEND PROTO_HDRS ${PROTO_HDR})
+  list(APPEND PROTO_SRCS ${PROTO_SRC})
+endforeach()
+
+add_library(evaluation_cc_proto ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(evaluation_cc_proto libprotobuf)
+
+add_library(data "${PROJECT_SOURCE_DIR}/data.cc" "${PROJECT_SOURCE_DIR}/data.h")
+target_link_libraries(data
+  evaluation_utils
+  common_byte_coding
+  Boost::math
+  Boost::multiprecision
+  absl::flat_hash_set
+  absl::memory
+  absl::random_random
+  absl::strings
+  csv-parser
+)
+
+add_library(per_stripe_bloom "${PROJECT_SOURCE_DIR}/per_stripe_bloom.h")
+target_link_libraries(per_stripe_bloom
+  data
+  evaluation_utils
+  index_structure
+  absl::strings
+  leveldb
+)
+
+add_library(xor_filter "${PROJECT_SOURCE_DIR}/xor_filter.h")
+target_link_libraries(xor_filter
+  absl::strings
+  xor_singleheader
+)
+
+add_library(per_stripe_xor "${PROJECT_SOURCE_DIR}/per_stripe_xor.h")
+target_link_libraries(per_stripe_xor
+  data
+  evaluation_utils
+  index_structure
+  absl::strings
+  xor_singleheader
+)
+
+add_library(cuckoo_index "${PROJECT_SOURCE_DIR}/cuckoo_index.cc" "${PROJECT_SOURCE_DIR}/cuckoo_index.h")
+target_link_libraries(cuckoo_index
+  cuckoo_kicker
+  cuckoo_utils
+  evaluation_utils
+  fingerprint_store
+  index_structure
+  common_byte_coding
+  common_profiling
+  common_rle_bitmap
+  absl::flat_hash_map
+  absl::memory
+  absl::strings
+)
+
+add_library(cuckoo_kicker "${PROJECT_SOURCE_DIR}/cuckoo_kicker.cc" "${PROJECT_SOURCE_DIR}/cuckoo_kicker.h")
+target_link_libraries(cuckoo_kicker
+  cuckoo_utils
+  absl::flat_hash_map
+  absl::random_random
+)
+
+add_library(evaluation_utils "${PROJECT_SOURCE_DIR}/evaluation_utils.cc" "${PROJECT_SOURCE_DIR}/evaluation_utils.h")
+target_link_libraries(evaluation_utils
+  evaluation_cc_proto
+  common_bitmap
+  common_rle_bitmap
+  croaring
+  absl::memory
+  absl::strings
+  Boost::iostreams
+)
+
+add_library(cuckoo_utils "${PROJECT_SOURCE_DIR}/cuckoo_utils.cc" "${PROJECT_SOURCE_DIR}/cuckoo_utils.h")
+target_link_libraries(cuckoo_utils
+  common_bit_packing
+  common_bitmap
+  common_byte_coding
+  croaring
+  absl::flat_hash_set
+  absl::city
+  absl::memory
+  absl::strings
+  absl::str_format
+)
+
+add_library(fingerprint_store "${PROJECT_SOURCE_DIR}/fingerprint_store.cc" "${PROJECT_SOURCE_DIR}/fingerprint_store.h")
+target_link_libraries(fingerprint_store
+  cuckoo_utils
+  evaluation_utils
+  common_bitmap
+  common_rle_bitmap
+  absl::flat_hash_map
+  absl::strings
+)
+
+add_library(index_structure "${PROJECT_SOURCE_DIR}/index_structure.h")
+target_link_libraries(index_structure
+  data
+  evaluation_cc_proto
+)
+
+add_library(zone_map "${PROJECT_SOURCE_DIR}/zone_map.h")
+target_link_libraries(zone_map
+  data
+  evaluation_utils
+  index_structure
+  absl::memory
+  absl::strings
+)
+
+add_library(evaluator "${PROJECT_SOURCE_DIR}/evaluator.cc" "${PROJECT_SOURCE_DIR}/evaluator.h")
+target_link_libraries(evaluator
+  data
+  evaluation_cc_proto
+  index_structure
+  absl::random_random
+  absl::str_format
+)
+
+add_executable(evaluate "${PROJECT_SOURCE_DIR}/evaluate.cc")
+target_link_libraries(evaluate 
+  cuckoo_index
+  cuckoo_utils
+  data
+  evaluation_cc_proto
+  evaluation_utils
+  evaluator
+  index_structure
+  per_stripe_bloom
+  per_stripe_xor
+  zone_map
+  absl::flags
+  absl::flags_parse
+  absl::memory
+  absl::strings
+  absl::str_format
+)

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -1,0 +1,19 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+set(BUILD_GMOCK ON CACHE BOOL "" FORCE)
+set(BUILD_GTEST OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+        gtest
+        GIT_REPOSITORY "https://github.com/google/googletest.git"
+        GIT_TAG 10b1902d893ea8cc43c69541d70868f91af3646b
+        PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(gtest)
+FetchContent_GetProperties(gtest SOURCE_DIR GTEST_INCLUDE_DIR)
+include_directories(${GTEST_INCLUDE_DIR}/googlemock/include)
+include_directories(${GTEST_INCLUDE_DIR}/googletest/include)

--- a/cmake/leveldb.cmake
+++ b/cmake/leveldb.cmake
@@ -1,0 +1,19 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+SET(LEVELDB_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+SET(LEVELDB_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+SET(LEVELDB_INSTALL ON CACHE BOOL "" FORCE)
+FetchContent_Declare(
+        leveldb
+        GIT_REPOSITORY "https://github.com/google/leveldb.git"
+        GIT_TAG 78b39d68c15ba020c0d60a3906fb66dbf1697595
+        PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(leveldb)
+FetchContent_GetProperties(leveldb SOURCE_DIR LEVELDB_INCLUDE_DIR)
+include_directories(${LEVELDB_INCLUDE_DIR})

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -1,0 +1,23 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+SET(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+SET(protobuf_BUILD_CONFORMANCE  OFF CACHE BOOL "" FORCE)
+SET(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(protobuf_BUILD_EXPORT OFF CACHE BOOL "" FORCE)
+SET(protobuf_WITH_ZLIB OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+        protobuf
+        GIT_REPOSITORY "https://github.com/protocolbuffers/protobuf.git"
+        GIT_TAG v3.15.6
+        PATCH_COMMAND ""
+        SOURCE_SUBDIR cmake
+)
+FetchContent_MakeAvailable(protobuf)
+FetchContent_GetProperties(protobuf SOURCE_DIR PROTOBUF_INCLUDE_DIR)
+SET(PROTOBUF_INCLUDE_DIR "${PROTOBUF_INCLUDE_DIR}/src")
+include_directories(${PROTOBUF_INCLUDE_DIR})

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,0 +1,75 @@
+include(googletest)
+
+add_executable(data_test "${PROJECT_SOURCE_DIR}/data_test.cc")
+target_link_libraries(data_test 
+  data
+  gtest_main
+)
+
+add_executable(per_stripe_bloom_test "${PROJECT_SOURCE_DIR}/per_stripe_bloom_test.cc")
+target_link_libraries(per_stripe_bloom_test 
+  per_stripe_bloom
+  gtest_main
+)
+
+add_executable(xor_filter_test "${PROJECT_SOURCE_DIR}/xor_filter_test.cc")
+target_link_libraries(xor_filter_test 
+  xor_filter
+  gtest_main
+)
+
+add_executable(per_stripe_xor_test "${PROJECT_SOURCE_DIR}/per_stripe_xor_test.cc")
+target_link_libraries(per_stripe_xor_test 
+  per_stripe_xor
+  gtest_main
+)
+
+add_executable(cuckoo_index_test "${PROJECT_SOURCE_DIR}/cuckoo_index_test.cc")
+target_link_libraries(cuckoo_index_test 
+  cuckoo_index
+  gtest_main
+)
+
+add_executable(cuckoo_kicker_test "${PROJECT_SOURCE_DIR}/cuckoo_kicker_test.cc")
+target_link_libraries(cuckoo_kicker_test 
+  cuckoo_kicker
+  gtest_main
+)
+
+add_executable(evaluation_utils_test "${PROJECT_SOURCE_DIR}/evaluation_utils_test.cc")
+target_link_libraries(evaluation_utils_test 
+  evaluation_utils
+  gtest_main
+)
+
+add_executable(cuckoo_utils_test "${PROJECT_SOURCE_DIR}/cuckoo_utils_test.cc")
+target_link_libraries(cuckoo_utils_test 
+  cuckoo_utils
+  evaluation_utils
+  gtest_main
+)
+
+add_executable(fingerprint_store_test "${PROJECT_SOURCE_DIR}/fingerprint_store_test.cc")
+target_link_libraries(fingerprint_store_test 
+  fingerprint_store
+  gtest_main
+)
+
+add_executable(zone_map_test "${PROJECT_SOURCE_DIR}/zone_map_test.cc")
+target_link_libraries(zone_map_test 
+  zone_map
+  gtest_main
+)
+
+add_executable(bitmap_benchmark_test "${PROJECT_SOURCE_DIR}/bitmap_benchmark_test.cc")
+target_link_libraries(bitmap_benchmark_test 
+  evaluation_utils
+  common_bitmap
+  common_rle_bitmap
+  croaring
+  absl::flags
+  absl::memory
+  absl::strings
+  benchmark
+  gtest_main
+)

--- a/cmake/xor_singleheader.cmake
+++ b/cmake/xor_singleheader.cmake
@@ -1,0 +1,17 @@
+include(FetchContent)
+set(FETCHCONTENT_QUIET ON)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+set(BUILD_SHARED_LIBS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Git REQUIRED)
+
+FetchContent_Declare(
+    xor_singleheader
+    GIT_REPOSITORY "https://github.com/FastFilter/xor_singleheader.git"
+    GIT_TAG 6cea6a4dcf2f18a0e3b9b9e0b94d6012b804ffa1
+    PATCH_COMMAND ""
+)
+FetchContent_MakeAvailable(xor_singleheader)
+FetchContent_GetProperties(xor_singleheader SOURCE_DIR XOR_SINGLEHEADER_INCLUDE_DIR)
+add_library(xor_singleheader INTERFACE)
+target_include_directories(xor_singleheader INTERFACE ${XOR_SINGLEHEADER_INCLUDE_DIR})

--- a/xor_filter.h
+++ b/xor_filter.h
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include "absl/strings/str_cat.h"
-#include "xor_singleheader/include/xorfilter.h"
+#include "include/xorfilter.h"
 
 namespace ci {
 

--- a/xor_singleheader.BUILD
+++ b/xor_singleheader.BUILD
@@ -23,5 +23,4 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
   name = "xorfilter",
   hdrs = ["include/xorfilter.h"],
-  include_prefix = "xor_singleheader",
 )


### PR DESCRIPTION
This cl aims to add CMake support to Cuckoo Index.

Some notes:
- I am by no means a CMake expert so there might be room for improvement in what I did.
- The Boost version for bazel and CMake are different. CMake needs version `boost-1.77.0` for the dependency management to work. In that version, Boost Math is broken which I was able to fix in CMake, but did not find a way to fix in the bazelrules. When the next Boost, both the Boost version for bazel and CMake can be upgraded to the same version.
- The `include_prefix` for xorfilter has been removed as I was not able to find a similar feature for CMake.

I tested building all the CMake targets I added and I also built all the bazel targets to make sure they still work.
